### PR TITLE
Exclude slf4j-simple from s-c-starter-turbine-amqp

### DIFF
--- a/spring-cloud-starter-turbine-amqp/pom.xml
+++ b/spring-cloud-starter-turbine-amqp/pom.xml
@@ -68,6 +68,12 @@
 			<artifactId>turbine-core</artifactId>
 			<!-- TODO: turbine 1.0.0 is coming from s-c-netflix pom import -->
 			<version>${turbine.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-simple</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>


### PR DESCRIPTION
`slf4j-simple` snuck into the dependencies in Angel.SR4. This may not be the correct place to add the exclusion.